### PR TITLE
Replace next/image with <img> in landing page components

### DIFF
--- a/components/LandingPageContent/FifthFoldPicturesBackground.test.tsx
+++ b/components/LandingPageContent/FifthFoldPicturesBackground.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from "@testing-library/react";
 import FifthFoldPicturesBackground, {
   PICTURE_URLS,
 } from "./FifthFoldPicturesBackground";
-import { checkNextImageSrc } from "@/lib/testing-utils/misc";
 
 it("renders <img> elements with proper 'src' attribute", () => {
   render(<FifthFoldPicturesBackground />);
@@ -10,6 +9,6 @@ it("renders <img> elements with proper 'src' attribute", () => {
   const images = screen.queryAllByRole("img") as HTMLImageElement[];
 
   images.forEach((image, index) => {
-    checkNextImageSrc(image, PICTURE_URLS[index]);
+    expect(image.getAttribute("src")).toBe(PICTURE_URLS[index]);
   });
 });

--- a/components/LandingPageContent/FifthFoldPicturesBackground.tsx
+++ b/components/LandingPageContent/FifthFoldPicturesBackground.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import styles from "./FifthFoldPicturesBackground.module.css";
 
@@ -33,7 +32,7 @@ const FifthFoldPicturesBackground = () => {
 
   const BackgroundPicture = ({ pictureIndex }: { pictureIndex: number }) => {
     return (
-      <Image
+      <img
         src={PICTURE_URLS[pictureIndex]}
         width={236}
         height={350}

--- a/components/LandingPageContent/FourthFold.module.css
+++ b/components/LandingPageContent/FourthFold.module.css
@@ -16,7 +16,6 @@
 
 .coverPicture {
   position: absolute;
-  inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/components/LandingPageContent/FourthFold.module.css
+++ b/components/LandingPageContent/FourthFold.module.css
@@ -15,6 +15,10 @@
 }
 
 .coverPicture {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   cursor: pointer;
 }

--- a/components/LandingPageContent/FourthFold.tsx
+++ b/components/LandingPageContent/FourthFold.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import styles from "./FourthFold.module.css";
 import TextAndExploreButton from "./TextAndExploreButton";
@@ -17,22 +16,20 @@ const FourthFold = () => {
   return (
     <div className={styles.container} data-testid="landing-page-fourth-fold">
       <div className={styles.picturesArea}>
-        <Image
+        <img
           src="https://s.pinimg.com/webapp/shop-bd0c8a04.png"
           alt={t("FourthFold.LIP_SHADE_PICTURE_ALT")}
-          fill
-          sizes="50vw"
           className={styles.coverPicture}
         />
         <div className={styles.picturesOverlay}>
-          <Image
+          <img
             src="https://s.pinimg.com/webapp/creator-pin-img-491ebb56.png"
             alt={t("FourthFold.EYE_SHADE_PICTURE_ALT")}
             width={216}
             height={384}
             className={styles.secondaryPicture}
           />
-          <Image
+          <img
             src="https://s.pinimg.com/webapp/creator-avatar-d7a05622.png"
             alt={t("FourthFold.CREATOR_THUMBNAIL_PICTURE")}
             width={96}

--- a/components/LandingPageContent/PictureSliderPicture.module.css
+++ b/components/LandingPageContent/PictureSliderPicture.module.css
@@ -8,7 +8,6 @@
 .image {
   border-radius: 16px;
   position: absolute;
-  inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/components/LandingPageContent/PictureSliderPicture.module.css
+++ b/components/LandingPageContent/PictureSliderPicture.module.css
@@ -7,6 +7,10 @@
 
 .image {
   border-radius: 16px;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   transition:
     opacity 0.7s ease-in-out,

--- a/components/LandingPageContent/PictureSliderPicture.test.tsx
+++ b/components/LandingPageContent/PictureSliderPicture.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import PictureSliderPicture, { IMAGE_URLS } from "./PictureSliderPicture";
-import { checkNextImageSrc } from "@/lib/testing-utils/misc";
 
 it("renders <img> element with proper 'src' attribute", () => {
   const props = {
@@ -15,5 +14,7 @@ it("renders <img> element with proper 'src' attribute", () => {
 
   const image = screen.getByRole("img") as HTMLImageElement;
 
-  checkNextImageSrc(image, `https://i.pinimg.com/${IMAGE_URLS.FOOD[0]}`);
+  expect(image.getAttribute("src")).toBe(
+    `https://i.pinimg.com/${IMAGE_URLS.FOOD[0]}`,
+  );
 });

--- a/components/LandingPageContent/PictureSliderPicture.tsx
+++ b/components/LandingPageContent/PictureSliderPicture.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import styles from "./PictureSliderPicture.module.css";
 import { PICTURE_SLIDER_TOPICS } from "./PictureSliderPictures";
 
@@ -135,16 +134,10 @@ const PictureSliderPicture = ({
 
   return (
     <div className={styles.container}>
-      <Image
+      <img
         src={imageURL}
         alt={topicLabel.toLowerCase()}
-        fill
-        sizes="236px"
         className={imageClasses}
-        priority={
-          topicIndex ===
-          0 /* Pre-load images of first topic to improve performance */
-        }
         data-testid={`picture-slider-picture-${topicLabel.toLowerCase()}-${imageIndex}`}
       />
     </div>

--- a/components/LandingPageContent/SecondFold.module.css
+++ b/components/LandingPageContent/SecondFold.module.css
@@ -79,7 +79,6 @@
 .picture {
   border-radius: 50px;
   position: absolute;
-  inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/components/LandingPageContent/SecondFold.module.css
+++ b/components/LandingPageContent/SecondFold.module.css
@@ -78,6 +78,11 @@
 
 .picture {
   border-radius: 50px;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .textArea {

--- a/components/LandingPageContent/SecondFold.tsx
+++ b/components/LandingPageContent/SecondFold.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSearch } from "@fortawesome/free-solid-svg-icons";
 import { useTranslation } from "react-i18next";
@@ -21,38 +20,30 @@ const SecondFold = () => {
       <div className={styles.picturesArea}>
         <div className={styles.picturesContainer}>
           <div className={styles.pictureLeftContainer}>
-            <Image
+            <img
               src="https://s.pinimg.com/webapp/left-511a9304.png"
               alt={t("SecondFold.CHICKEN_PLATE")}
-              fill
-              sizes="204px"
               className={styles.picture}
             />
           </div>
           <div className={styles.pictureTopRightContainer}>
-            <Image
+            <img
               src="https://s.pinimg.com/webapp/topRight-d0230035.png"
               alt={t("SecondFold.CHICKEN_PLATE")}
-              fill
-              sizes="178px"
               className={styles.picture}
             />
           </div>
           <div className={styles.pictureBottomRightContainer}>
-            <Image
+            <img
               src="https://s.pinimg.com/webapp/right-88044782.png"
               alt={t("SecondFold.CHICKEN_PLATE")}
-              fill
-              sizes="164px"
               className={styles.picture}
             />
           </div>
           <div className={styles.pictureCenterContainer}>
-            <Image
+            <img
               src="https://s.pinimg.com/webapp/center-77497603.png"
               alt={t("SecondFold.CHICKEN_PLATE")}
-              fill
-              sizes="298px"
               className={styles.picture}
             />
           </div>

--- a/components/LandingPageContent/ThirdFold.module.css
+++ b/components/LandingPageContent/ThirdFold.module.css
@@ -68,6 +68,11 @@
 
 .mainPicture {
   border-radius: 50px;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .pictureOverlay {

--- a/components/LandingPageContent/ThirdFold.module.css
+++ b/components/LandingPageContent/ThirdFold.module.css
@@ -69,7 +69,6 @@
 .mainPicture {
   border-radius: 50px;
   position: absolute;
-  inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/components/LandingPageContent/ThirdFold.tsx
+++ b/components/LandingPageContent/ThirdFold.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import TextAndExploreButton from "./TextAndExploreButton";
 import styles from "./ThirdFold.module.css";
@@ -26,11 +25,9 @@ const ThirdFold = () => {
       <div className={styles.picturesArea}>
         <div className={styles.picturesContainer}>
           <div className={styles.pictureTopLeftContainer}>
-            <Image
+            <img
               src="https://s.pinimg.com/webapp/future-home-vibes-55a673b9.png"
               alt={t("ThirdFold.FUTURE_HOME_VIBES")}
-              fill
-              sizes="4OOpx"
               className={styles.mainPicture}
             />
             <div
@@ -42,21 +39,21 @@ const ThirdFold = () => {
                 {t("ThirdFold.FUTURE_HOME_VIBES")}
               </div>
               <div className={styles.smallPicturesContainer}>
-                <Image
+                <img
                   src="https://s.pinimg.com/webapp/future-home1-f4037b6b.png"
                   alt={t("ThirdFold.FUTURE_HOME_VIBES")}
                   width={90}
                   height={130}
                   className={styles.smallPicture}
                 />
-                <Image
+                <img
                   src="https://s.pinimg.com/webapp/future-home2-c70a8738.png"
                   alt={t("ThirdFold.FUTURE_HOME_VIBES")}
                   width={90}
                   height={130}
                   className={styles.smallPicture}
                 />
-                <Image
+                <img
                   src="https://s.pinimg.com/webapp/future-home3-ac09e50f.png"
                   alt={t("ThirdFold.FUTURE_HOME_VIBES")}
                   width={90}
@@ -67,11 +64,9 @@ const ThirdFold = () => {
             </div>
           </div>
           <div className={styles.pictureTopRightContainer}>
-            <Image
+            <img
               src="https://s.pinimg.com/webapp/scandinavian-bedroom-917ad89c.png"
               alt={t("ThirdFold.SCANDINAVIAN_BEDROOM")}
-              fill
-              sizes="220px"
               className={styles.mainPicture}
             />
             <div
@@ -85,11 +80,9 @@ const ThirdFold = () => {
             </div>
           </div>
           <div className={styles.pictureMiddleRightContainer}>
-            <Image
+            <img
               src="https://s.pinimg.com/webapp/deck-of-dreams-fb527bf1.png"
               alt={t("ThirdFold.DECK_OF_MY_DREAMS")}
-              fill
-              sizes="160px"
               className={styles.mainPicture}
             />
             <div
@@ -103,11 +96,9 @@ const ThirdFold = () => {
             </div>
           </div>
           <div className={styles.pictureBottomLeftContainer}>
-            <Image
+            <img
               src="https://s.pinimg.com/webapp/serve-my-drinks-263547ea.png"
               alt={t("ThirdFold.SERVE_DRINKS")}
-              fill
-              sizes="220px"
               className={styles.mainPicture}
             />
             <div
@@ -121,11 +112,9 @@ const ThirdFold = () => {
             </div>
           </div>
           <div className={styles.pictureBottomRightContainer}>
-            <Image
+            <img
               src="https://s.pinimg.com/webapp/bathroom-upgrade-48ebb8fc.png"
               alt={t("ThirdFold.BATHROOM_UPGRADE")}
-              fill
-              sizes="220px"
               className={styles.mainPicture}
             />
             <div


### PR DESCRIPTION
## Summary

- Replace `next/image` `<Image>` with plain `<img>` in: `SecondFold`, `ThirdFold`, `FourthFold`, `FifthFoldPicturesBackground`, `PictureSliderPicture`
- For `fill`-based images, add equivalent CSS to the image class: `position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover`
- Update `FifthFoldPicturesBackground.test.tsx` and `PictureSliderPicture.test.tsx` to assert `src` directly instead of via `checkNextImageSrc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)