### PR TITLE
Replace next/image with <img> for logo images

### DIFF
--- a/components/Header/HeaderUnauthenticated.tsx
+++ b/components/Header/HeaderUnauthenticated.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import OverlayModal from "../OverlayModal/OverlayModal";
 import LoginFormContainer from "../LoginForm/LoginFormContainer";
@@ -49,7 +48,7 @@ const HeaderUnauthenticated = () => {
   return (
     <nav className={styles.container}>
       <a href="/" className={styles.logoContainer}>
-        <Image src="/images/logo.svg" alt="PinIt logo" width={32} height={32} />
+        <img src="/images/logo.svg" alt="PinIt logo" width={32} height={32} />
         <h1 className={styles.logoHeader}>PinIt</h1>
       </a>
       {/* Trick: we render <HeaderSearchBar /> with a key containing the current pathname.

--- a/components/LoginForm/LoginForm.tsx
+++ b/components/LoginForm/LoginForm.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleXmark, faSpinner } from "@fortawesome/free-solid-svg-icons";
-import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import LabelledTextInput from "../LabelledTextInput/LabelledTextInput";
 import styles from "./LoginForm.module.css";
@@ -61,7 +60,7 @@ const LoginForm = ({
 
   return (
     <div className={styles.container}>
-      <Image
+      <img
         src="/images/logo.svg"
         alt="PinIt logo"
         width={40}

--- a/components/SignupForm/SignupForm.tsx
+++ b/components/SignupForm/SignupForm.tsx
@@ -1,7 +1,6 @@
 import { useRef, useEffect } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner, faCircleXmark } from "@fortawesome/free-solid-svg-icons";
-import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import LabelledTextInput from "../LabelledTextInput/LabelledTextInput";
 import styles from "./SignupForm.module.css";
@@ -69,7 +68,7 @@ const SignupForm = ({
 
   return (
     <div className={styles.container}>
-      <Image
+      <img
         src="/images/logo.svg"
         alt="PinIt logo"
         width={40}


### PR DESCRIPTION
## Summary

- Replace `next/image` `<Image>` with plain `<img>` in: `HeaderUnauthenticated`, `LoginForm`, `SignupForm`
- All three are simple fixed-size logos (`/images/logo.svg`), no CSS changes needed, no test assertions on these images

🤖 Generated with [Claude Code](https://claude.com/claude-code)