### PR TITLE
Replace next/link with react-router-dom Link in presentational components

### DIFF
--- a/components/AccountDetailsView/BoardThumbnail.test.tsx
+++ b/components/AccountDetailsView/BoardThumbnail.test.tsx
@@ -3,9 +3,14 @@ import BoardThumbnail from "./BoardThumbnail";
 import { MOCK_API_RESPONSES_SERIALIZED } from "@/lib/testing-utils/mockAPIResponses";
 import { API_ENDPOINT_ACCOUNT_DETAILS } from "@/lib/constants";
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 
 const renderComponent = ({ board }: { board: BoardWithBasicDetails }) => {
-  render(<BoardThumbnail username="johndoe" board={board} />);
+  render(
+    <MemoryRouter>
+      <BoardThumbnail username="johndoe" board={board} />
+    </MemoryRouter>,
+  );
 };
 
 it("renders cover picture and two secondary pictures if all are provided", () => {

--- a/components/AccountDetailsView/BoardThumbnail.tsx
+++ b/components/AccountDetailsView/BoardThumbnail.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { Link } from "react-router-dom";
 import { BoardWithBasicDetails } from "@/lib/types/frontendTypes";
 import styles from "./BoardThumbnail.module.css";
 
@@ -78,7 +78,7 @@ const BoardThumbnail = ({ username, board }: BoardThumbnailProps) => {
 
   return (
     <div className={styles.container}>
-      <Link href={`/${username}/${slug}/`} className={styles.content}>
+      <Link to={`/${username}/${slug}`} className={styles.content}>
         <div className={styles.imagesContainer}>
           {coverImage}
           <div className={styles.secondaryImages}>

--- a/components/BoardDetailsView/BoardDetailsView.test.tsx
+++ b/components/BoardDetailsView/BoardDetailsView.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import BoardDetailsView from "./BoardDetailsView";
 import { MOCK_API_RESPONSES_SERIALIZED } from "@/lib/testing-utils/mockAPIResponses";
 import { API_ENDPOINT_BOARD_DETAILS } from "@/lib/constants";
@@ -7,7 +8,11 @@ import en from "@/public/locales/en/BoardDetails.json";
 const board = MOCK_API_RESPONSES_SERIALIZED[API_ENDPOINT_BOARD_DETAILS];
 
 const renderComponent = () => {
-  render(<BoardDetailsView board={board} />);
+  render(
+    <MemoryRouter>
+      <BoardDetailsView board={board} />
+    </MemoryRouter>,
+  );
 };
 
 it("renders board details", () => {

--- a/components/LandingPageContent/FourthFold.test.tsx
+++ b/components/LandingPageContent/FourthFold.test.tsx
@@ -1,7 +1,12 @@
 import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import FourthFold from "./FourthFold";
 
 // This component is purely presentational:
 it("renders", () => {
-  render(<FourthFold />);
+  render(
+    <MemoryRouter>
+      <FourthFold />
+    </MemoryRouter>,
+  );
 });

--- a/components/LandingPageContent/LandingPageContent.test.tsx
+++ b/components/LandingPageContent/LandingPageContent.test.tsx
@@ -1,9 +1,18 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import LandingPageContent, {
   SCROLLING_DEBOUNCING_TIME_MS,
   SCROLL_DIRECTIONS,
 } from "./LandingPageContent";
 import userEvent from "@testing-library/user-event";
+
+const renderComponent = () => {
+  render(
+    <MemoryRouter>
+      <LandingPageContent />
+    </MemoryRouter>,
+  );
+};
 
 // Since the <FifthFold /> component relies on `useRouter` and other
 // specific methods, we mock the whole component for simplicity:
@@ -43,7 +52,7 @@ const scrollAfterDebounceTime = ({
 it("scrolls from fold to fold, down and up", () => {
   jest.useFakeTimers();
 
-  render(<LandingPageContent />);
+  renderComponent();
 
   const content = screen.getByTestId("landing-page-content");
   expect(content.className).toEqual("content"); // i.e. first fold active
@@ -74,7 +83,7 @@ it("scrolls from fold to fold, down and up", () => {
 });
 
 it("does not scroll down to second fold in case of lateral wheel event", () => {
-  render(<LandingPageContent />);
+  renderComponent();
 
   fireEvent.wheel(document, { deltaX: 10 });
 
@@ -85,7 +94,7 @@ it("does not scroll down to second fold in case of lateral wheel event", () => {
 it("does not move to third fold if user scrolls twice within debounce time", () => {
   jest.useFakeTimers();
 
-  render(<LandingPageContent />);
+  renderComponent();
 
   fireEvent.wheel(document, { deltaY: 100 });
 
@@ -105,7 +114,7 @@ it("does not move to third fold if user scrolls twice within debounce time", () 
 });
 
 it("scrolls to second fold when user clicks on the hero carret", async () => {
-  render(<LandingPageContent />);
+  renderComponent();
 
   const heroCarret = screen.getByTestId("picture-slider-carret-icon");
   await userEvent.click(heroCarret);
@@ -117,7 +126,7 @@ it("scrolls to second fold when user clicks on the hero carret", async () => {
 it("scrolls back to top upon click on 'send back to top'", async () => {
   jest.useFakeTimers();
 
-  render(<LandingPageContent />);
+  renderComponent();
 
   const content = screen.getByTestId("landing-page-content");
 

--- a/components/LandingPageContent/SecondFold.test.tsx
+++ b/components/LandingPageContent/SecondFold.test.tsx
@@ -1,7 +1,12 @@
 import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import SecondFold from "./SecondFold";
 
 // This component is purely presentational:
 it("renders", () => {
-  render(<SecondFold />);
+  render(
+    <MemoryRouter>
+      <SecondFold />
+    </MemoryRouter>,
+  );
 });

--- a/components/LandingPageContent/TextAndExploreButton.test.tsx
+++ b/components/LandingPageContent/TextAndExploreButton.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import TextAndExploreButton from "./TextAndExploreButton";
 import { FOLD } from "./LandingPageContent";
 
@@ -9,7 +10,11 @@ it("renders elements with the proper classes", () => {
     labels: { header: "", paragraph: "", link: "" },
   };
 
-  render(<TextAndExploreButton {...props} />);
+  render(
+    <MemoryRouter>
+      <TextAndExploreButton {...props} />
+    </MemoryRouter>,
+  );
 
   const container = screen.getByTestId("text-and-explore-button-container");
   expect(container.className).toEqual("container containerSecondFold");

--- a/components/LandingPageContent/TextAndExploreButton.tsx
+++ b/components/LandingPageContent/TextAndExploreButton.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { Link } from "react-router-dom";
 import { FOLD } from "./LandingPageContent";
 import styles from "./TextAndExploreButton.module.css";
 import { useTranslation } from "react-i18next";
@@ -37,7 +37,7 @@ const TextAndExploreButton = ({
       <div className={styles.header}>{labels.header}</div>
       <div className={styles.paragraph}>{labels.paragraph}</div>
       <Link
-        href={linkTarget}
+        to={linkTarget}
         className={buttonClasses}
         data-testid="text-and-explore-button-button"
       >

--- a/components/LandingPageContent/ThirdFold.test.tsx
+++ b/components/LandingPageContent/ThirdFold.test.tsx
@@ -1,7 +1,12 @@
 import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import ThirdFold from "./ThirdFold";
 
 // This component is purely presentational:
 it("renders", () => {
-  render(<ThirdFold />);
+  render(
+    <MemoryRouter>
+      <ThirdFold />
+    </MemoryRouter>,
+  );
 });

--- a/components/PinCreationView/PinCreationViewContainer.test.tsx
+++ b/components/PinCreationView/PinCreationViewContainer.test.tsx
@@ -40,10 +40,8 @@ const expectInputFieldsToBeDisabled = () => {
 const renderComponent = () => {
   render(
     <MemoryRouter>
-      <div>
-        <ToastContainer />
-        <PinCreationViewContainer />
-      </div>
+      <ToastContainer />
+      <PinCreationViewContainer />
     </MemoryRouter>,
   );
 };

--- a/components/PinCreationView/PinCreationViewContainer.test.tsx
+++ b/components/PinCreationView/PinCreationViewContainer.test.tsx
@@ -5,6 +5,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import PinCreationViewContainer from "./PinCreationViewContainer";
 import en from "@/public/locales/en/PinCreation.json";
 import { act } from "react-dom/test-utils";
@@ -38,10 +39,12 @@ const expectInputFieldsToBeDisabled = () => {
 
 const renderComponent = () => {
   render(
-    <div>
-      <ToastContainer />
-      <PinCreationViewContainer />
-    </div>,
+    <MemoryRouter>
+      <div>
+        <ToastContainer />
+        <PinCreationViewContainer />
+      </div>
+    </MemoryRouter>,
   );
 };
 

--- a/components/PinCreationView/SuccessToastMessage.test.tsx
+++ b/components/PinCreationView/SuccessToastMessage.test.tsx
@@ -1,8 +1,13 @@
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import SuccessToastMessage from "./SuccessToastMessage";
 
 it("renders link with proper 'href' attribute", () => {
-  render(<SuccessToastMessage pinId="123456789" />);
+  render(
+    <MemoryRouter>
+      <SuccessToastMessage pinId="123456789" />
+    </MemoryRouter>,
+  );
 
   const link = screen.getByRole("link") as HTMLAnchorElement;
 

--- a/components/PinCreationView/SuccessToastMessage.tsx
+++ b/components/PinCreationView/SuccessToastMessage.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import Link from "next/link";
+import { Link } from "react-router-dom";
 import styles from "./SuccessToastMessage.module.css";
 
 type SuccessToastMessageProps = {
@@ -15,7 +15,7 @@ const SuccessToastMessage = ({ pinId }: SuccessToastMessageProps) => {
       data-testid="success-toast-message"
     >
       <p>{t("PIN_PUBLISHED")}</p>
-      <Link href={`/pin/${pinId}/`} className={styles.successToastMessageLink}>
+      <Link to={`/pin/${pinId}`} className={styles.successToastMessageLink}>
         {t("VIEW")}
       </Link>
     </div>

--- a/components/PinDetailsView/PinDetailsView.test.tsx
+++ b/components/PinDetailsView/PinDetailsView.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import PinDetailsView from "./PinDetailsView";
 import en from "@/public/locales/en/PinDetails.json";
 import { MOCK_API_RESPONSES_SERIALIZED } from "@/lib/testing-utils/mockAPIResponses";
@@ -10,7 +11,11 @@ const defaultPin = MOCK_API_RESPONSES_SERIALIZED[API_ENDPOINT_PIN_DETAILS];
 const renderComponent = ({
   pin = defaultPin,
 }: { pin?: PinWithFullDetails } = {}) => {
-  return render(<PinDetailsView pin={pin} />);
+  return render(
+    <MemoryRouter>
+      <PinDetailsView pin={pin} />
+    </MemoryRouter>,
+  );
 };
 
 it("renders all required elements", () => {

--- a/components/PinDetailsView/PinDetailsView.tsx
+++ b/components/PinDetailsView/PinDetailsView.tsx
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
-import Link from "next/link";
+import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { PinWithFullDetails } from "@/lib/types/frontendTypes";
 import styles from "./PinDetailsView.module.css";
@@ -16,7 +16,7 @@ const PinDetailsView = ({ pin }: PinDetailsViewProps) => {
 
   return (
     <div className={styles.container}>
-      <Link href="/">
+      <Link to="/">
         <button className={styles.backButton}>
           <FontAwesomeIcon icon={faArrowLeft} size="lg" />
         </button>
@@ -38,7 +38,7 @@ const PinDetailsView = ({ pin }: PinDetailsViewProps) => {
             <p className={styles.pinDescription}>{pin.description}</p>
           )}
           <Link
-            href={`/${pin.author.username}/`}
+            to={`/${pin.author.username}`}
             className={styles.authorDetails}
             data-testid="pin-author-details"
           >

--- a/components/PinsBoard/PinThumbnail.test.tsx
+++ b/components/PinsBoard/PinThumbnail.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import PinThumbnail from "./PinThumbnail";
 import { MOCK_API_RESPONSES_SERIALIZED } from "@/lib/testing-utils/mockAPIResponses";
 import { API_ROUTE_PIN_SUGGESTIONS } from "@/lib/constants";
@@ -7,21 +8,23 @@ const pin = MOCK_API_RESPONSES_SERIALIZED[API_ROUTE_PIN_SUGGESTIONS].results[0];
 
 const renderComponent = () => {
   render(
-    <PinThumbnail
-      pin={pin}
-      isInFirstColumn={false}
-      isInLastColumn={false}
-      boards={[]}
-      isHovered={false}
-      indexBoardWhereJustSaved={null}
-      isSaveFlyoutOpen={false}
-      isSaving={false}
-      handleMouseEnterImage={() => {}}
-      handleMouseLeaveImage={() => {}}
-      handleClickSave={() => {}}
-      getClickHandlerForBoard={() => () => {}}
-      handleClickOutOfSaveFlyout={() => {}}
-    />,
+    <MemoryRouter>
+      <PinThumbnail
+        pin={pin}
+        isInFirstColumn={false}
+        isInLastColumn={false}
+        boards={[]}
+        isHovered={false}
+        indexBoardWhereJustSaved={null}
+        isSaveFlyoutOpen={false}
+        isSaving={false}
+        handleMouseEnterImage={() => {}}
+        handleMouseLeaveImage={() => {}}
+        handleClickSave={() => {}}
+        getClickHandlerForBoard={() => () => {}}
+        handleClickOutOfSaveFlyout={() => {}}
+      />
+    </MemoryRouter>,
   );
 };
 

--- a/components/PinsBoard/PinThumbnail.tsx
+++ b/components/PinsBoard/PinThumbnail.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import styles from "./PinThumbnail.module.css";
 import {
@@ -95,7 +95,7 @@ const PinThumbnail = ({
   return (
     <div className={styles.container} data-testid="pin-thumbnail">
       <Link
-        href={`/pin/${pin.id}/`}
+        to={`/pin/${pin.id}`}
         className={styles.imageContainer}
         onMouseEnter={handleMouseEnterImage}
         onMouseLeave={handleMouseLeaveImage}
@@ -114,14 +114,14 @@ const PinThumbnail = ({
         {shouldShowImageOverlay && imageOverlay}
       </Link>
       {pin.title && (
-        <Link href={`/pin/${pin.id}`} className={styles.title}>
+        <Link to={`/pin/${pin.id}`} className={styles.title}>
           {pin.title}
         </Link>
       )}
       <Link
         className={styles.authorDetails}
         data-testid="pin-author-details"
-        href={`/${pin.author.username}/`}
+        to={`/${pin.author.username}`}
       >
         {pin.author.profilePictureURL && (
           <img

--- a/components/PinsBoard/PinThumbnailContainer.test.tsx
+++ b/components/PinsBoard/PinThumbnailContainer.test.tsx
@@ -5,6 +5,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import PinThumbnailContainer from "./PinThumbnailContainer";
 import { AccountContext } from "@/contexts/accountContext";
 import userEvent from "@testing-library/user-event";
@@ -49,14 +50,16 @@ const renderComponent = () => {
   };
 
   render(
-    <AccountContext.Provider value={accountContext}>
-      <ToastContainer />
-      <PinThumbnailContainer
-        pin={pin}
-        isInFirstColumn={false}
-        isInLastColumn={false}
-      />
-    </AccountContext.Provider>,
+    <MemoryRouter>
+      <AccountContext.Provider value={accountContext}>
+        <ToastContainer />
+        <PinThumbnailContainer
+          pin={pin}
+          isInFirstColumn={false}
+          isInLastColumn={false}
+        />
+      </AccountContext.Provider>
+    </MemoryRouter>,
   );
 };
 

--- a/components/PinsBoard/PinsBoard.test.tsx
+++ b/components/PinsBoard/PinsBoard.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import PinsBoard from "./PinsBoard";
 import { mockIntersectionObserver } from "@/lib/testing-utils/misc";
 import en from "@/public/locales/en/PinsSearch.json";
@@ -19,12 +20,14 @@ const pins = MOCK_API_RESPONSES_SERIALIZED[API_ROUTE_PIN_SUGGESTIONS].results;
 
 const renderComponent = () => {
   render(
-    <PinsBoard
-      pins={pins}
-      isFetching={false}
-      fetchFailed={false}
-      onScrolledToBottom={jest.fn()}
-    />,
+    <MemoryRouter>
+      <PinsBoard
+        pins={pins}
+        isFetching={false}
+        fetchFailed={false}
+        onScrolledToBottom={jest.fn()}
+      />
+    </MemoryRouter>,
   );
 };
 

--- a/components/PinsBoard/PinsBoardContainer.test.tsx
+++ b/components/PinsBoard/PinsBoardContainer.test.tsx
@@ -1,4 +1,5 @@
 import { render, waitFor, act, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import en from "@/public/locales/en/PinsBoard.json";
 import PinsBoardContainer from "./PinsBoardContainer";
 import { ToastContainer } from "react-toastify";
@@ -30,13 +31,13 @@ beforeEach(() => {
 
 const renderComponent = () => {
   render(
-    <>
+    <MemoryRouter>
       <ToastContainer />
       <PinsBoardContainer
         initialPins={initialPins}
         fetchPinsAPIRoute={API_ROUTE_PIN_SUGGESTIONS}
       />
-    </>,
+    </MemoryRouter>,
   );
 };
 

--- a/setupJest.js
+++ b/setupJest.js
@@ -1,4 +1,9 @@
+import { TextEncoder, TextDecoder } from "util";
 import { enableMocks } from "jest-fetch-mock";
+
+// react-router-dom v7 uses TextEncoder/TextDecoder which jsdom doesn't provide
+globalThis.TextEncoder = TextEncoder;
+globalThis.TextDecoder = TextDecoder;
 import Common from "./public/locales/en/Common.json";
 import HeaderUnauthenticated from "./public/locales/en/HeaderUnauthenticated.json";
 import HeaderAuthenticated from "./public/locales/en/HeaderAuthenticated.json";


### PR DESCRIPTION
## Summary
- Replaces `import Link from "next/link"` with `import { Link } from "react-router-dom"` in 5 components: `TextAndExploreButton`, `SuccessToastMessage`, `BoardThumbnail`, `PinThumbnail`, `PinDetailsView`
- Changes `href` prop to `to` on all affected `<Link>` elements, removing trailing slashes for consistency
- Wraps renders in `MemoryRouter` in all test files that (directly or transitively) render these components — 15 test files in total
- Adds `TextEncoder`/`TextDecoder` polyfill to `setupJest.js`, required by react-router-dom v7 in the jsdom test environment

## Test plan
- [ ] All 38 test suites pass locally (`pnpm jest`)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)