### PR TITLE
Replace next/navigation with react-router-dom equivalents

### DIFF
--- a/components/Header/HeaderAuthenticated.test.tsx
+++ b/components/Header/HeaderAuthenticated.test.tsx
@@ -1,19 +1,11 @@
 import { render, screen } from "@testing-library/react";
-import { usePathname } from "next/navigation";
+import { MemoryRouter } from "react-router-dom";
 import HeaderAuthenticated from "./HeaderAuthenticated";
 import en from "@/public/locales/en/HeaderAuthenticated.json";
 import { HeaderSearchBarContextProvider } from "@/contexts/headerSearchBarContext";
 import { createRef } from "react";
 
-jest.mock("next/navigation", () => ({
-  useRouter: jest.fn(),
-  usePathname: jest.fn(),
-  useSearchParams: jest.fn(),
-}));
-
-const mockedUsePathname = usePathname as jest.Mock;
-
-const renderComponent = () => {
+const renderComponent = (pathname = "/en") => {
   const props = {
     username: "johndoe",
     profilePictureURL: null,
@@ -31,16 +23,16 @@ const renderComponent = () => {
   const mockRef = createRef<HTMLButtonElement>();
 
   render(
-    <HeaderSearchBarContextProvider>
-      <HeaderAuthenticated ref={mockRef} {...props} />
-    </HeaderSearchBarContextProvider>,
+    <MemoryRouter initialEntries={[pathname]}>
+      <HeaderSearchBarContextProvider>
+        <HeaderAuthenticated ref={mockRef} {...props} />
+      </HeaderSearchBarContextProvider>
+    </MemoryRouter>,
   );
 };
 
 it("when on home route, should mark home link as active and not mark create link as active", () => {
-  mockedUsePathname.mockReturnValue("/en");
-
-  renderComponent();
+  renderComponent("/en");
 
   const homeLink = screen.getByText(en.NAV_ITEM_HOME);
   expect(homeLink).toHaveClass("navigationItemActive");
@@ -50,9 +42,7 @@ it("when on home route, should mark home link as active and not mark create link
 });
 
 it("when on pin creation route, should mark create link as active and not mark home link as active", () => {
-  mockedUsePathname.mockReturnValue("/en/pin-creation-tool");
-
-  renderComponent();
+  renderComponent("/en/pin-creation-tool");
 
   const homeLink = screen.getByText(en.NAV_ITEM_HOME);
   expect(homeLink).not.toHaveClass("navigationItemActive");

--- a/components/Header/HeaderAuthenticated.tsx
+++ b/components/Header/HeaderAuthenticated.tsx
@@ -1,5 +1,5 @@
-import { usePathname } from "next/navigation";
-import Link from "next/link";
+import { useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleDown, faUser } from "@fortawesome/free-solid-svg-icons";
 import HeaderSearchBarContainer from "./HeaderSearchBarContainer";
@@ -40,7 +40,7 @@ const HeaderAuthenticated = forwardRef<
     handleClickOutOfAccountOptionsFlyout,
   } = props;
 
-  const pathname = usePathname();
+  const { pathname } = useLocation();
 
   const { t } = useTranslation("HeaderAuthenticated");
 
@@ -74,7 +74,7 @@ const HeaderAuthenticated = forwardRef<
   return (
     <nav className={styles.container}>
       <div className={styles.headerItemsContainer}>
-        <Link href="/" className={styles.logoContainer}>
+        <Link to="/" className={styles.logoContainer}>
           <img
             src="/images/logo.svg"
             alt="PinIt logo"
@@ -82,10 +82,10 @@ const HeaderAuthenticated = forwardRef<
             height={24}
           />
         </Link>
-        <Link href="/" className={classHomeLink}>
+        <Link to="/" className={classHomeLink}>
           {t("NAV_ITEM_HOME")}
         </Link>
-        <Link href="/pin-creation-tool/" className={classCreateLink}>
+        <Link to="/pin-creation-tool" className={classCreateLink}>
           {t("NAV_ITEM_CREATE")}
         </Link>
         {/* Trick: we render <HeaderSearchBar /> with a key containing the current pathname.
@@ -96,7 +96,7 @@ const HeaderAuthenticated = forwardRef<
         />
         {username && (
           <Link
-            href={`/${username}`}
+            to={`/${username}`}
             className={styles.profileLink}
             data-testid="profile-link"
             onMouseEnter={handleMouseEnterProfileLink}

--- a/components/Header/HeaderAuthenticatedContainer.test.tsx
+++ b/components/Header/HeaderAuthenticatedContainer.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import userEvent from "@testing-library/user-event";
 import { screen, fireEvent, render, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import en from "@/public/locales/en/HeaderAuthenticated.json";
 import HeaderAuthenticatedContainer from "./HeaderAuthenticatedContainer";
 import { MockLocalStorage } from "@/lib/testing-utils/misc";
@@ -24,12 +25,6 @@ jest.mock("@/components/Header/AccountOptionsFlyout", () => {
   return MockedAccountOptionsFlyout;
 });
 
-jest.mock("next/navigation", () => ({
-  useRouter: jest.fn(),
-  usePathname: jest.fn(),
-  useSearchParams: jest.fn(),
-}));
-
 localStorage = new MockLocalStorage();
 
 const defaultAccount =
@@ -41,11 +36,13 @@ const renderComponent = ({
   account?: AccountWithPrivateDetails | null;
 } = {}) => {
   render(
-    <AccountContext.Provider value={{ account, setAccount: jest.fn() }}>
-      <HeaderSearchBarContextProvider>
-        <HeaderAuthenticatedContainer />
-      </HeaderSearchBarContextProvider>
-    </AccountContext.Provider>,
+    <MemoryRouter>
+      <AccountContext.Provider value={{ account, setAccount: jest.fn() }}>
+        <HeaderSearchBarContextProvider>
+          <HeaderAuthenticatedContainer />
+        </HeaderSearchBarContextProvider>
+      </AccountContext.Provider>
+    </MemoryRouter>,
   );
 };
 

--- a/components/Header/HeaderSearchBar.tsx
+++ b/components/Header/HeaderSearchBar.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useEffect, useRef } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleXmark, faSearch } from "@fortawesome/free-solid-svg-icons";
-import { useRouter } from "next/navigation";
+import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import styles from "./HeaderSearchBar.module.css";
 import classNames from "classnames";
@@ -29,7 +29,7 @@ const HeaderSearchBar = ({
   searchSuggestions,
   getSuggestionLinkClickHandler,
 }: HeaderSearchBarProps) => {
-  const router = useRouter();
+  const navigate = useNavigate();
 
   const { t } = useTranslation("HeaderAuthenticated");
 
@@ -38,7 +38,7 @@ const HeaderSearchBar = ({
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    router.push(`/search/pins?q=${inputValue}`);
+    navigate(`/search/pins?q=${inputValue}`);
   };
 
   const handleKeyDown = (event: KeyboardEvent) => {

--- a/components/Header/HeaderSearchBarContainer.test.tsx
+++ b/components/Header/HeaderSearchBarContainer.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
 import HeaderSearchBarContainer, {
   AUTOCOMPLETE_DEBOUNCE_TIME_MS,
 } from "./HeaderSearchBarContainer";
@@ -10,14 +11,11 @@ import {
   MOCK_API_RESPONSES_JSON,
 } from "@/lib/testing-utils/mockAPIResponses";
 
-const mockPush = jest.fn();
+const mockNavigate = jest.fn();
 
-jest.mock("next/navigation", () => ({
-  useRouter: () => ({
-    push: mockPush,
-  }),
-  usePathname: jest.fn(),
-  useSearchParams: jest.fn(),
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
 }));
 
 const typeSearchTerm = async (searchTerm: string) => {
@@ -34,9 +32,11 @@ const clickSearchInput = async () => {
 
 const renderComponent = () => {
   render(
-    <HeaderSearchBarContextProvider>
-      <HeaderSearchBarContainer />
-    </HeaderSearchBarContextProvider>,
+    <MemoryRouter>
+      <HeaderSearchBarContextProvider>
+        <HeaderSearchBarContainer />
+      </HeaderSearchBarContextProvider>
+    </MemoryRouter>,
   );
 };
 
@@ -160,7 +160,7 @@ it("navigates to search route when user clicks suggestion", async () => {
 
     await userEvent.click(searchSuggestionsListItems[1]);
 
-    expect(mockPush).toHaveBeenLastCalledWith(
+    expect(mockNavigate).toHaveBeenLastCalledWith(
       "/search/pins?q=foo suggestion 1",
     );
   });
@@ -173,7 +173,7 @@ it("navigates to /search/pins route when user types and presses Enter", async ()
 
   await userEvent.keyboard("[Enter]");
 
-  expect(mockPush).toHaveBeenLastCalledWith("/search/pins?q=foo");
+  expect(mockNavigate).toHaveBeenLastCalledWith("/search/pins?q=foo");
 });
 
 it("does not display any suggestion in case of KO response from the API", async () => {

--- a/components/Header/HeaderSearchBarContainer.tsx
+++ b/components/Header/HeaderSearchBarContainer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import debounce from "lodash/debounce";
-import { useRouter } from "next/navigation";
+import { useNavigate } from "react-router-dom";
 import { API_ROUTE_SEARCH_SUGGESTIONS } from "@/lib/constants";
 import HeaderSearchBar from "./HeaderSearchBar";
 import { useHeaderSearchBarContext } from "@/contexts/headerSearchBarContext";
@@ -36,7 +36,7 @@ const getSuggestionsWithSearchTermAtTop = ({
 };
 
 const HeaderSearchBarContainer = () => {
-  const router = useRouter();
+  const navigate = useNavigate();
 
   const [searchSuggestions, setSearchSuggestions] = useState<string[]>([]);
 
@@ -60,7 +60,7 @@ const HeaderSearchBarContainer = () => {
       // updated based on the route, but updating it here will give a better
       // impression of reactivity.
 
-      router.push(`/search/pins?q=${suggestion}`);
+      navigate(`/search/pins?q=${suggestion}`);
     };
   };
 

--- a/components/Header/HeaderUnauthenticated.test.tsx
+++ b/components/Header/HeaderUnauthenticated.test.tsx
@@ -2,20 +2,16 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import en from "@/public/locales/en/LandingPageContent.json";
 import HeaderUnauthenticated from "./HeaderUnauthenticated";
-import { usePathname } from "next/navigation";
+import { MemoryRouter } from "react-router-dom";
 import { HeaderSearchBarContextProvider } from "@/contexts/headerSearchBarContext";
 
-jest.mock("next/navigation", () => ({
-  useRouter: jest.fn(),
-  usePathname: jest.fn(),
-  useSearchParams: jest.fn(),
-}));
-
-const renderComponent = () => {
+const renderComponent = (pathname = "/some-page") => {
   render(
-    <HeaderSearchBarContextProvider>
-      <HeaderUnauthenticated />
-    </HeaderSearchBarContextProvider>,
+    <MemoryRouter initialEntries={[pathname]}>
+      <HeaderSearchBarContextProvider>
+        <HeaderUnauthenticated />
+      </HeaderSearchBarContextProvider>
+    </MemoryRouter>,
   );
 };
 
@@ -32,9 +28,7 @@ it("renders with search bar when pathname is not '/'", () => {
 });
 
 it("renders without search bar when pathname is '/'", () => {
-  (usePathname as jest.Mock).mockReturnValue("/");
-
-  renderComponent();
+  renderComponent("/");
 
   expect(screen.queryByTestId("header-search-bar")).toBeNull();
 });

--- a/components/Header/HeaderUnauthenticated.tsx
+++ b/components/Header/HeaderUnauthenticated.tsx
@@ -1,16 +1,14 @@
-"use client";
-
 import { useTranslation } from "react-i18next";
 import OverlayModal from "../OverlayModal/OverlayModal";
 import LoginFormContainer from "../LoginForm/LoginFormContainer";
 import SignupFormContainer from "../SignupForm/SignupFormContainer";
 import styles from "./HeaderUnauthenticated.module.css";
 import { useState } from "react";
-import { usePathname } from "next/navigation";
+import { useLocation } from "react-router-dom";
 import HeaderSearchBarContainer from "./HeaderSearchBarContainer";
 
 const HeaderUnauthenticated = () => {
-  const pathname = usePathname();
+  const { pathname } = useLocation();
 
   const isOnHomePage = pathname === "/" || pathname === "/en";
 

--- a/components/LoginForm/LoginFormContainer.test.tsx
+++ b/components/LoginForm/LoginFormContainer.test.tsx
@@ -16,13 +16,11 @@ import { MockLocalStorage } from "@/lib/testing-utils/misc";
 
 localStorage = new MockLocalStorage();
 
-const mockRouterRefresh = jest.fn();
-
-jest.mock("next/navigation", () => ({
-  useRouter: () => ({
-    refresh: mockRouterRefresh,
-  }),
-}));
+const mockReload = jest.fn();
+Object.defineProperty(window, "location", {
+  configurable: true,
+  value: { ...window.location, reload: mockReload },
+});
 
 const typeInEmailInput = async (text: string) => {
   const emailInput = screen.getByLabelText(en.LoginForm.EMAIL);
@@ -57,7 +55,7 @@ const renderComponent = () => {
 };
 
 beforeEach(() => {
-  mockRouterRefresh.mockClear();
+  mockReload.mockClear();
 });
 
 it("displays relevant input errors", async () => {
@@ -111,7 +109,7 @@ and reloads the page upon successful response`, async () => {
     MOCK_API_RESPONSES_JSON[API_ROUTE_OBTAIN_TOKEN].access_token_expiration_utc,
   );
 
-  expect(mockRouterRefresh).toHaveBeenCalledTimes(1);
+  expect(mockReload).toHaveBeenCalledTimes(1);
 });
 
 it(`sets the access token's expiration date in local storage 
@@ -132,7 +130,7 @@ and reloads the page upon successful response for demo login`, async () => {
     MOCK_API_RESPONSES_JSON[API_ROUTE_OBTAIN_TOKEN].access_token_expiration_utc,
   );
 
-  expect(mockRouterRefresh).toHaveBeenCalledTimes(1);
+  expect(mockReload).toHaveBeenCalledTimes(1);
 });
 
 it("displays relevant errors when receiving KO responses", async () => {

--- a/components/LoginForm/LoginFormContainer.tsx
+++ b/components/LoginForm/LoginFormContainer.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import {
   ERROR_CODE_INVALID_PASSWORD,
   ERROR_CODE_INVALID_EMAIL,
@@ -34,8 +33,6 @@ const computeFormErrors = (values: { email: string; password: string }) => {
 const LoginFormContainer = ({
   handleClickNoAccountYet,
 }: LoginFormContainerProps) => {
-  const router = useRouter();
-
   const [credentials, setCredentials] = useState({
     email: "",
     password: "",
@@ -97,7 +94,7 @@ const LoginFormContainer = ({
 
     setAccessTokenExpirationDate(responseData.access_token_expiration_utc);
 
-    router.refresh();
+    window.location.reload();
   };
 
   const fetchTokensAndThrow = async ({

--- a/components/SignupForm/SignupFormContainer.test.tsx
+++ b/components/SignupForm/SignupFormContainer.test.tsx
@@ -14,13 +14,11 @@ import {
 
 const handleClickAlreadyHaveAccount = () => {}; // NB: this behavior will be tested in <HeaderUnauthenticatedClient />
 
-const mockRouterRefresh = jest.fn();
-
-jest.mock("next/navigation", () => ({
-  useRouter: () => ({
-    refresh: mockRouterRefresh,
-  }),
-}));
+const mockReload = jest.fn();
+Object.defineProperty(window, "location", {
+  configurable: true,
+  value: { ...window.location, reload: mockReload },
+});
 
 const renderComponent = () => {
   render(
@@ -122,7 +120,7 @@ and reloads the page upon successful response`, async () => {
     MOCK_API_RESPONSES_JSON[API_ROUTE_SIGN_UP].access_token_expiration_utc,
   );
 
-  expect(mockRouterRefresh).toHaveBeenCalledTimes(1);
+  expect(mockReload).toHaveBeenCalledTimes(1);
 });
 
 it("displays relevant error when receiving KO responses", async () => {

--- a/components/SignupForm/SignupFormContainer.tsx
+++ b/components/SignupForm/SignupFormContainer.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import {
   API_ROUTE_SIGN_UP,
   ERROR_CODE_EMAIL_ALREADY_SIGNED_UP,
@@ -48,8 +47,6 @@ const computeFormErrors = (values: {
 const SignupFormContainer = ({
   handleClickAlreadyHaveAccount,
 }: SignupFormContainerProps) => {
-  const router = useRouter();
-
   const [formData, setFormData] = useState({
     email: "",
     password: "",
@@ -105,7 +102,7 @@ const SignupFormContainer = ({
 
     setAccessTokenExpirationDate(responseData.access_token_expiration_utc);
 
-    router.refresh();
+    window.location.reload();
   };
 
   const fetchSignup = async () => {

--- a/contexts/headerSearchBarContext.tsx
+++ b/contexts/headerSearchBarContext.tsx
@@ -6,7 +6,7 @@ import {
   ReactNode,
   useEffect,
 } from "react";
-import { useSearchParams, usePathname } from "next/navigation";
+import { useLocation, useSearchParams } from "react-router-dom";
 
 type State = {
   inputValue: string;
@@ -52,8 +52,8 @@ export const HeaderSearchBarContextProvider = ({
 }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
+  const { pathname } = useLocation();
+  const [searchParams] = useSearchParams();
 
   // Initialize the input value to the search param if present:
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Replaces all `next/navigation` imports in component and context files with react-router-dom equivalents:
  - `usePathname()` → `useLocation().pathname`
  - `useSearchParams()` → `useSearchParams()[0]` (same `.get()` API)
  - `useRouter().push(url)` → `navigate(url)` via `useNavigate()`
  - `router.refresh()` → `window.location.reload()` (in `LoginFormContainer` and `SignupFormContainer`)
- Removes `"use client"` directive from `HeaderUnauthenticated.tsx` (Next.js-only)
- Updates all affected test files: replaces `jest.mock("next/navigation", ...)` with `MemoryRouter` wrappers and react-router-dom hook mocks
- Adds `TextEncoder`/`TextDecoder` polyfill to `setupJest.js`

No `next/navigation` imports remain outside the `app/` directory.

## Test plan
- [ ] All 38 test suites pass locally (`pnpm jest`)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)