### PR TITLE
Scaffold Express API server to replace Next.js API routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "vite",
+    "dev": "concurrently --kill-others-on-fail --names \"vite,server\" \"vite\" \"ts-node --project server/tsconfig.json server/index.ts\"",
+    "dev:client": "vite",
+    "dev:server": "ts-node --project server/tsconfig.json server/index.ts",
     "build": "vite build",
     "start": "vite preview",
     "lint": "eslint .",
@@ -30,6 +32,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.35.1",
+    "@types/cookie-parser": "^1.4.6",
     "@testing-library/dom": "^9.2.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
@@ -46,6 +49,8 @@
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vitejs/plugin-react": "^4.0.0",
+    "concurrently": "^9.0.0",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.33.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.4.3
         version: 14.6.1(@testing-library/dom@9.3.4)
+      '@types/cookie-parser':
+        specifier: ^1.4.6
+        version: 1.4.10(@types/express@4.17.25)
       '@types/cors':
         specifier: ^2.8.13
         version: 2.8.19
@@ -108,6 +111,12 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.0.0
         version: 4.7.0(vite@6.4.2(@types/node@18.19.130))
+      concurrently:
+        specifier: ^9.0.0
+        version: 9.2.1
+      cookie-parser:
+        specifier: ^1.4.6
+        version: 1.4.7
       cors:
         specifier: ^2.8.5
         version: 2.8.6
@@ -926,6 +935,11 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/cookie-parser@1.4.10':
+    resolution: {integrity: sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==}
+    peerDependencies:
+      '@types/express': '*'
+
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
@@ -1352,6 +1366,11 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
@@ -1362,6 +1381,13 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-parser@1.4.7:
+    resolution: {integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==}
+    engines: {node: '>= 0.8.0'}
+
+  cookie-signature@1.0.6:
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
@@ -2838,6 +2864,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
@@ -2905,6 +2934,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -3072,6 +3105,10 @@ packages:
   tr46@3.0.0:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
     engines: {node: '>=12'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -4095,6 +4132,10 @@ snapshots:
     dependencies:
       '@types/node': 18.19.130
 
+  '@types/cookie-parser@1.4.10(@types/express@4.17.25)':
+    dependencies:
+      '@types/express': 4.17.25
+
   '@types/cors@2.8.19':
     dependencies:
       '@types/node': 18.19.130
@@ -4620,6 +4661,15 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+
   content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
@@ -4627,6 +4677,13 @@ snapshots:
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie-parser@1.4.7:
+    dependencies:
+      cookie: 0.7.2
+      cookie-signature: 1.0.6
+
+  cookie-signature@1.0.6: {}
 
   cookie-signature@1.0.7: {}
 
@@ -6492,6 +6549,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safe-array-concat@1.1.4:
     dependencies:
       call-bind: 1.0.9
@@ -6585,6 +6646,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.3: {}
 
   side-channel-list@1.0.1:
     dependencies:
@@ -6772,6 +6835,8 @@ snapshots:
   tr46@3.0.0:
     dependencies:
       punycode: 2.3.1
+
+  tree-kill@1.2.2: {}
 
   ts-api-utils@2.5.0(typescript@5.4.5):
     dependencies:

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,360 @@
+import cookieParser from "cookie-parser";
+import express, { Request, Response } from "express";
+import {
+  ACCESS_TOKEN_COOKIE_KEY,
+  API_BASE_URL,
+  API_ENDPOINT_CREATE_PIN,
+  API_ENDPOINT_MY_ACCOUNT_DETAILS,
+  API_ENDPOINT_OBTAIN_DEMO_TOKEN,
+  API_ENDPOINT_OBTAIN_TOKEN,
+  API_ENDPOINT_PIN_SUGGESTIONS,
+  API_ENDPOINT_REFRESH_TOKEN,
+  API_ENDPOINT_SAVE_PIN,
+  API_ENDPOINT_SEARCH_PINS,
+  API_ENDPOINT_SEARCH_SUGGESTIONS,
+  API_ENDPOINT_SIGN_UP,
+  REFRESH_TOKEN_COOKIE_KEY,
+} from "../lib/constants";
+
+const PORT = 3001;
+
+const app = express();
+app.use(express.json());
+app.use(cookieParser());
+
+type BackendTokenResponse = {
+  access_token: string;
+  refresh_token: string;
+  access_token_expiration_utc: string;
+};
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  path: "/",
+  sameSite: "lax" as const,
+};
+
+// Buffer a readable stream (used for proxying multipart bodies)
+const collectBody = async (req: Request): Promise<Buffer> => {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req as unknown as AsyncIterable<Buffer>) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+};
+
+const backendFetch = async ({
+  endpoint,
+  method = "GET",
+  body,
+  headers = {},
+  accessToken,
+}: {
+  endpoint: string;
+  method?: string;
+  body?: string | Buffer;
+  headers?: Record<string, string>;
+  accessToken?: string;
+}) => {
+  const requestHeaders: Record<string, string> = { ...headers };
+  if (accessToken) {
+    requestHeaders["Authorization"] = `Bearer ${accessToken}`;
+  }
+  return fetch(`${API_BASE_URL}/${endpoint}`, {
+    method,
+    body,
+    headers: requestHeaders,
+  });
+};
+
+const sendProxyResponse = async (
+  backendResponse: globalThis.Response,
+  res: Response
+) => {
+  let data;
+  try {
+    data = await backendResponse.json();
+  } catch {
+    return res.status(500).json({ errors: ["unparsable_backend_response"] });
+  }
+  return res.status(backendResponse.status).json(data);
+};
+
+const setAuthCookies = (
+  res: Response,
+  data: { access_token: string; refresh_token: string }
+) => {
+  res.cookie(ACCESS_TOKEN_COOKIE_KEY, data.access_token, COOKIE_OPTIONS);
+  res.cookie(REFRESH_TOKEN_COOKIE_KEY, data.refresh_token, COOKIE_OPTIONS);
+};
+
+// POST /api/user/sign-up
+app.post("/api/user/sign-up", async (req: Request, res: Response) => {
+  const { email, password, birthdate } = req.body;
+
+  let backendResponse;
+  try {
+    backendResponse = await backendFetch({
+      endpoint: API_ENDPOINT_SIGN_UP,
+      method: "POST",
+      body: JSON.stringify({ email, password, birthdate }),
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch {
+    return res.status(500).json({ errors: ["backend_fetch_failed"] });
+  }
+
+  let data: BackendTokenResponse;
+  try {
+    data = (await backendResponse.json()) as BackendTokenResponse;
+  } catch {
+    return res.status(500).json({ errors: ["unparsable_backend_response"] });
+  }
+
+  if (!backendResponse.ok) {
+    return res.status(backendResponse.status).json(data);
+  }
+
+  setAuthCookies(res, data);
+  return res.json({
+    access_token_expiration_utc: data.access_token_expiration_utc,
+  });
+});
+
+// POST /api/user/obtain-token
+app.post("/api/user/obtain-token", async (req: Request, res: Response) => {
+  const { email, password } = req.body;
+
+  let backendResponse;
+  try {
+    backendResponse = await backendFetch({
+      endpoint: API_ENDPOINT_OBTAIN_TOKEN,
+      method: "POST",
+      body: JSON.stringify({ email, password }),
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch {
+    return res.status(500).json({ errors: ["backend_fetch_failed"] });
+  }
+
+  let data: BackendTokenResponse;
+  try {
+    data = (await backendResponse.json()) as BackendTokenResponse;
+  } catch {
+    return res.status(500).json({ errors: ["unparsable_backend_response"] });
+  }
+
+  if (!backendResponse.ok) {
+    return res.status(backendResponse.status).json(data);
+  }
+
+  setAuthCookies(res, data);
+  return res.json({
+    access_token_expiration_utc: data.access_token_expiration_utc,
+  });
+});
+
+// GET /api/user/obtain-demo-token
+app.get(
+  "/api/user/obtain-demo-token",
+  async (_req: Request, res: Response) => {
+    let backendResponse;
+    try {
+      backendResponse = await backendFetch({
+        endpoint: API_ENDPOINT_OBTAIN_DEMO_TOKEN,
+      });
+    } catch {
+      return res.status(500).json({ errors: ["backend_fetch_failed"] });
+    }
+
+    let data: BackendTokenResponse;
+    try {
+      data = (await backendResponse.json()) as BackendTokenResponse;
+    } catch {
+      return res.status(500).json({ errors: ["unparsable_backend_response"] });
+    }
+
+    if (!backendResponse.ok) {
+      return res.status(backendResponse.status).json(data);
+    }
+
+    setAuthCookies(res, data);
+    return res.json({
+      access_token_expiration_utc: data.access_token_expiration_utc,
+    });
+  }
+);
+
+// POST /api/user/refresh-token
+app.post("/api/user/refresh-token", async (req: Request, res: Response) => {
+  const refreshToken = req.cookies[REFRESH_TOKEN_COOKIE_KEY];
+
+  if (!refreshToken) {
+    return res.status(400).json({ errors: ["missing_refresh_token"] });
+  }
+
+  let backendResponse;
+  try {
+    backendResponse = await backendFetch({
+      endpoint: API_ENDPOINT_REFRESH_TOKEN,
+      method: "POST",
+      body: JSON.stringify({ refresh_token: refreshToken }),
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch {
+    return res.status(500).json({ errors: ["backend_fetch_failed"] });
+  }
+
+  let data: Pick<BackendTokenResponse, "access_token" | "access_token_expiration_utc">;
+  try {
+    data = (await backendResponse.json()) as Pick<BackendTokenResponse, "access_token" | "access_token_expiration_utc">;
+  } catch {
+    return res.status(500).json({ errors: ["unparsable_backend_response"] });
+  }
+
+  if (!backendResponse.ok) {
+    return res.status(backendResponse.status).json(data);
+  }
+
+  res.cookie(ACCESS_TOKEN_COOKIE_KEY, data.access_token, COOKIE_OPTIONS);
+  return res.json({
+    access_token_expiration_utc: data.access_token_expiration_utc,
+  });
+});
+
+// GET /api/user/account-details
+app.get("/api/user/account-details", async (req: Request, res: Response) => {
+  const accessToken = req.cookies[ACCESS_TOKEN_COOKIE_KEY];
+  if (!accessToken) {
+    return res.status(401).json({ errors: ["missing_access_token"] });
+  }
+
+  let backendResponse;
+  try {
+    backendResponse = await backendFetch({
+      endpoint: API_ENDPOINT_MY_ACCOUNT_DETAILS,
+      accessToken,
+    });
+  } catch {
+    return res.status(500).json({ errors: ["backend_fetch_failed"] });
+  }
+
+  return sendProxyResponse(backendResponse, res);
+});
+
+// POST /api/user/log-out
+app.post("/api/user/log-out", (_req: Request, res: Response) => {
+  res.clearCookie(ACCESS_TOKEN_COOKIE_KEY, { path: "/" });
+  res.clearCookie(REFRESH_TOKEN_COOKIE_KEY, { path: "/" });
+  return res.status(200).end();
+});
+
+// GET /api/pin-suggestions
+app.get("/api/pin-suggestions", async (req: Request, res: Response) => {
+  const accessToken = req.cookies[ACCESS_TOKEN_COOKIE_KEY];
+  if (!accessToken) {
+    return res.status(401).json({ errors: ["missing_access_token"] });
+  }
+
+  const { page } = req.query;
+
+  let backendResponse;
+  try {
+    backendResponse = await backendFetch({
+      endpoint: `${API_ENDPOINT_PIN_SUGGESTIONS}?page=${page}`,
+      accessToken,
+    });
+  } catch {
+    return res.status(500).json({ errors: ["backend_fetch_failed"] });
+  }
+
+  return sendProxyResponse(backendResponse, res);
+});
+
+// GET /api/search
+app.get("/api/search", async (req: Request, res: Response) => {
+  const { q, page } = req.query;
+
+  let backendResponse;
+  try {
+    backendResponse = await backendFetch({
+      endpoint: `${API_ENDPOINT_SEARCH_PINS}/?q=${q}&page=${page}`,
+    });
+  } catch {
+    return res.status(500).json({ errors: ["backend_fetch_failed"] });
+  }
+
+  return sendProxyResponse(backendResponse, res);
+});
+
+// GET /api/search-suggestions
+app.get("/api/search-suggestions", async (req: Request, res: Response) => {
+  const { search } = req.query;
+
+  let backendResponse;
+  try {
+    backendResponse = await backendFetch({
+      endpoint: `${API_ENDPOINT_SEARCH_SUGGESTIONS}?search=${search}`,
+    });
+  } catch {
+    return res.status(500).json({ errors: ["backend_fetch_failed"] });
+  }
+
+  return sendProxyResponse(backendResponse, res);
+});
+
+// POST /api/create-pin (multipart/form-data — body is piped through raw)
+app.post("/api/create-pin", async (req: Request, res: Response) => {
+  const accessToken = req.cookies[ACCESS_TOKEN_COOKIE_KEY];
+  if (!accessToken) {
+    return res.status(401).json({ errors: ["missing_access_token"] });
+  }
+
+  const body = await collectBody(req);
+  const contentType = req.headers["content-type"];
+
+  let backendResponse;
+  try {
+    backendResponse = await backendFetch({
+      endpoint: API_ENDPOINT_CREATE_PIN,
+      method: "POST",
+      body,
+      headers: contentType ? { "Content-Type": contentType } : {},
+      accessToken,
+    });
+  } catch {
+    return res.status(500).json({ errors: ["backend_fetch_failed"] });
+  }
+
+  return sendProxyResponse(backendResponse, res);
+});
+
+// POST /api/save-pin
+app.post("/api/save-pin", async (req: Request, res: Response) => {
+  const accessToken = req.cookies[ACCESS_TOKEN_COOKIE_KEY];
+  if (!accessToken) {
+    return res.status(401).json({ errors: ["missing_access_token"] });
+  }
+
+  const { pin_id, board_id } = req.body;
+
+  let backendResponse;
+  try {
+    backendResponse = await backendFetch({
+      endpoint: API_ENDPOINT_SAVE_PIN,
+      method: "POST",
+      body: JSON.stringify({ pin_id, board_id }),
+      headers: { "Content-Type": "application/json" },
+      accessToken,
+    });
+  } catch {
+    return res.status(500).json({ errors: ["backend_fetch_failed"] });
+  }
+
+  return sendProxyResponse(backendResponse, res);
+});
+
+app.listen(PORT, () => {
+  console.log(`API server running on http://localhost:${PORT}`);
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "types": ["node"],
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["./**/*", "../lib/constants.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,5 +11,11 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+    proxy: {
+      "/api": {
+        target: "http://localhost:3001",
+        changeOrigin: true,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary

- Adds `server/index.ts`: an Express server on port 3001 that mirrors every Next.js API route (`/api/user/*`, `/api/pin-suggestions`, `/api/search`, `/api/search-suggestions`, `/api/create-pin`, `/api/save-pin`)
- Cookies (`accessToken`, `refreshToken`) remain `httpOnly`, set/cleared by Express the same way Next.js did
- Adds `server/tsconfig.json` for ts-node compilation of the server
- Updates `vite.config.ts` to proxy `/api/*` → `localhost:3001`, so the Vite dev app calls the same routes without any client-side changes
- Adds `concurrently` + `cookie-parser` devDependencies; updates `dev` script to start both Vite and the Express server together

## Test plan

- [ ] `pnpm install` picks up `concurrently` and `cookie-parser`
- [ ] `pnpm run dev:server` starts the Express server on port 3001 without errors
- [ ] `pnpm run dev` starts both Vite (3000) and Express (3001) together
- [ ] Login flow: POST `/api/user/obtain-token` sets `httpOnly` cookies and returns `access_token_expiration_utc`
- [ ] Token refresh: POST `/api/user/refresh-token` reads the `refreshToken` cookie, returns new `access_token_expiration_utc`
- [ ] Logout: POST `/api/user/log-out` clears both cookies
- [ ] Protected route (`/api/pin-suggestions`) returns 401 without the cookie and proxies correctly with it
- [ ] Public routes (`/api/search`, `/api/search-suggestions`) proxy to the backend without auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)